### PR TITLE
Fix invalid syntax highlighting across GraphEdit nodes

### DIFF
--- a/Assets/UI/GeneralTheme.tres
+++ b/Assets/UI/GeneralTheme.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Theme" load_steps=12 format=3 uid="uid://thbfepb48rke"]
 
-[ext_resource type="FontFile" uid="uid://cr7irh45ojvhq" path="res://Assets/Fonts/RobotoMono-VariableFont_wght.ttf" id="2_wg7ae"]
+[ext_resource type="FontFile" uid="uid://dbga3hs7ko0df" path="res://Assets/Fonts/RobotoMono-VariableFont_wght.ttf" id="2_wg7ae"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6u15c"]
 content_margin_top = 4.0

--- a/CodeEdit.tscn
+++ b/CodeEdit.tscn
@@ -1,12 +1,13 @@
 [gd_scene load_steps=6 format=3 uid="uid://du8buwy48dvor"]
 
-[ext_resource type="FontFile" uid="uid://cr7irh45ojvhq" path="res://Assets/Fonts/RobotoMono-VariableFont_wght.ttf" id="1_mh05q"]
+[ext_resource type="FontFile" uid="uid://dbga3hs7ko0df" path="res://Assets/Fonts/RobotoMono-VariableFont_wght.ttf" id="1_mh05q"]
 [ext_resource type="Script" path="res://CodeEdit.gd" id="2_37jka"]
-[ext_resource type="AudioStream" uid="uid://bpuuj0excj3p7" path="res://Assets/Sound/Type2.wav" id="3_voskr"]
+[ext_resource type="AudioStream" uid="uid://bugnbjxbttg72" path="res://Assets/Sound/Type2.wav" id="3_voskr"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_h0v5b"]
 
 [sub_resource type="CodeHighlighter" id="CodeHighlighter_cx3dy"]
+resource_local_to_scene = true
 number_color = Color(1, 1, 1, 1)
 symbol_color = Color(1, 1, 1, 1)
 function_color = Color(1, 1, 1, 1)
@@ -35,10 +36,10 @@ theme_override_font_sizes/font_size = 15
 theme_override_styles/focus = SubResource("StyleBoxEmpty_h0v5b")
 text = "bla bla"
 wrap_mode = 1
-draw_tabs = true
-syntax_highlighter = SubResource("CodeHighlighter_cx3dy")
 scroll_smooth = true
 caret_blink = true
+syntax_highlighter = SubResource("CodeHighlighter_cx3dy")
+draw_tabs = true
 line_folding = true
 gutters_draw_line_numbers = true
 indent_automatic_prefixes = Array[String]([":", "{", "[", "<", ">"])


### PR DESCRIPTION
Each node was using the same resource when it came to the Syntax Highlighting. At first, it appears to work when you create a new node; however, since the focus leaves the node when a new one is created, if you ever returned to the previous one then the node would end up fetching that new resource and updating the highlighting since they are all shared.

Switching the node to have the SyntaxHighlighter resource to be local to the scene seems to resolve the issue.