### PR TITLE
fix new_name str length

### DIFF
--- a/Editor.gd
+++ b/Editor.gd
@@ -95,7 +95,7 @@ func get_new_node(type:String, _node_name:String = ""):
 	var new_node = node_stack[type].res.instantiate()
 	node_stack[ type ].last_index = node_stack[ type ].last_index + 1
 
-	var new_name = type + "_" +str(node_stack[ type ].last_index)
+	var new_name = type + "_" +str(node_stack[ type ].last_index).lpad(10,"0")
 	if _node_name != "":
 		new_name = _node_name
 


### PR DESCRIPTION
Hello, Amber:

I saw in your YouTube video that you were having trouble sorting the dialog nodes in JSON. This is because the name of the nodes (new_name) are strings and not numbers, so a DIALOG_2 comes alphabetically after a DIALOG_1(5).

To avoid this issue, what I did was to add zeros using "padding". This is done with the str().lpad() method. 
Info: https://docs.godotengine.org/en/stable/classes/class_string.html#class-string-method-lpad

So the names of the nodes will be like DIALOG_0000000001 and DIALOG_0000000015 and JSON will sort them correctly, prioritizing the 0s.

(Unless you have like 9999999999 nodes then the 1000000000° node will again be the first, lol, but then you can adjust the paramenter in lpad() to add more than 10 digits of padding).

Hope it helps!